### PR TITLE
Add z-index to floating menu

### DIFF
--- a/src/pages/FloatingMenu/index.vue
+++ b/src/pages/FloatingMenu/index.vue
@@ -141,6 +141,7 @@ export default {
 
   &__floating-menu {
     position: absolute;
+    z-index: 1;
     margin-top: -0.25rem;
     visibility: hidden;
     opacity: 0;


### PR DESCRIPTION
Need a z-index: 1 for  the menu to work. Otherwise the buttons are not clickable. See https://github.com/scrumpy/tiptap/issues/363